### PR TITLE
Skip deployment status for noops

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -197,6 +197,7 @@ jobs:
           echo "status=${status}" >> "${GITHUB_OUTPUT}"
 
       - name: complete deployment status
+        if: ${{ needs.trigger.outputs.noop != 'true' && needs.trigger.outputs.deployment_id != '' }}
         env:
           DEPLOYMENT_ID: ${{ needs.trigger.outputs.deployment_id }}
           DEPLOY_STATUS: ${{ steps.result.outputs.status }}

--- a/test/policy.test.js
+++ b/test/policy.test.js
@@ -42,6 +42,7 @@ test("branch deployment keeps trusted logic separate from candidate content", ()
   assert.match(workflow, /path: \$\{\{ steps\.validate\.outputs\.working_path \}\}/);
   assert.match(workflow, /"\$\{GITHUB_WORKSPACE\}\/\$\{TRUSTED_PATH\}\/script\/build"/);
   assert.doesNotMatch(workflow, /\$\{WORKING_PATH\}\/script\//);
+  assert.match(workflow, /- name: complete deployment status\n\s+if: \$\{\{ needs\.trigger\.outputs\.noop != 'true' && needs\.trigger\.outputs\.deployment_id != '' \}\}/);
   assert.match(workflow, /version\.txt\?sha=\$\{EXPECTED_SHA\}/);
 });
 


### PR DESCRIPTION
## Summary

- skip the deployment-status API call when a noop has no deployment ID
- preserve lock cleanup, reactions, and the distinct noop result comment
- enforce the guard in repository policy tests