### PR TITLE
Preserve branch deploy command reactions

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -227,12 +227,7 @@ jobs:
           DEPLOY_STATUS: ${{ steps.result.outputs.status }}
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
-          INITIAL_REACTION_ID: ${{ needs.trigger.outputs.initial_reaction_id }}
         run: |
-          gh api \
-            --method DELETE \
-            "repos/${GH_REPO}/issues/comments/${COMMENT_ID}/reactions/${INITIAL_REACTION_ID}"
-
           reaction=rocket
           if [ "${DEPLOY_STATUS}" = "failure" ]; then
             reaction='-1'

--- a/test/policy.test.js
+++ b/test/policy.test.js
@@ -42,6 +42,7 @@ test("branch deployment keeps trusted logic separate from candidate content", ()
   assert.match(workflow, /path: \$\{\{ steps\.validate\.outputs\.working_path \}\}/);
   assert.match(workflow, /"\$\{GITHUB_WORKSPACE\}\/\$\{TRUSTED_PATH\}\/script\/build"/);
   assert.doesNotMatch(workflow, /\$\{WORKING_PATH\}\/script\//);
+  assert.doesNotMatch(workflow, /INITIAL_REACTION_ID|reactions\/\$\{INITIAL_REACTION_ID\}/);
   assert.match(workflow, /- name: complete deployment status\n\s+if: \$\{\{ needs\.trigger\.outputs\.noop != 'true' && needs\.trigger\.outputs\.deployment_id != '' \}\}/);
   assert.match(workflow, /version\.txt\?sha=\$\{EXPECTED_SHA\}/);
 });


### PR DESCRIPTION
## Summary

- stop trying to delete the branch-deploy Action reaction with a workflow token that does not own it
- retain the initial reaction and add the final success or failure reaction
- preserve lock cleanup and result comments, with regression coverage for the unsupported delete path