### PR TITLE
Remove unsupported deploy reactions

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -221,23 +221,6 @@ jobs:
             --method DELETE \
             "repos/${GH_REPO}/git/refs/heads/${ENVIRONMENT}-branch-deploy-lock"
 
-      - name: update command reaction
-        env:
-          COMMENT_ID: ${{ needs.trigger.outputs.comment_id }}
-          DEPLOY_STATUS: ${{ steps.result.outputs.status }}
-          GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          reaction=rocket
-          if [ "${DEPLOY_STATUS}" = "failure" ]; then
-            reaction='-1'
-          fi
-
-          gh api \
-            --method POST \
-            "repos/${GH_REPO}/issues/comments/${COMMENT_ID}/reactions" \
-            -f content="${reaction}"
-
       - name: post result comment
         env:
           ACTOR_HANDLE: ${{ needs.trigger.outputs.actor_handle }}

--- a/test/policy.test.js
+++ b/test/policy.test.js
@@ -42,7 +42,7 @@ test("branch deployment keeps trusted logic separate from candidate content", ()
   assert.match(workflow, /path: \$\{\{ steps\.validate\.outputs\.working_path \}\}/);
   assert.match(workflow, /"\$\{GITHUB_WORKSPACE\}\/\$\{TRUSTED_PATH\}\/script\/build"/);
   assert.doesNotMatch(workflow, /\$\{WORKING_PATH\}\/script\//);
-  assert.doesNotMatch(workflow, /INITIAL_REACTION_ID|reactions\/\$\{INITIAL_REACTION_ID\}/);
+  assert.doesNotMatch(workflow, /- name: update command reaction/);
   assert.match(workflow, /- name: complete deployment status\n\s+if: \$\{\{ needs\.trigger\.outputs\.noop != 'true' && needs\.trigger\.outputs\.deployment_id != '' \}\}/);
   assert.match(workflow, /version\.txt\?sha=\$\{EXPECTED_SHA\}/);
 });


### PR DESCRIPTION
## Summary

- remove custom command-reaction writes that GitHub rejects for workflow tokens
- keep branch-deploy's own acknowledgement reaction and use the authenticated result comment as the outcome
- preserve deployment status, lock cleanup, and distinct noop, success, and failure comments