### PR TITLE
Grant branch deploy comment permission

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -177,7 +177,7 @@ jobs:
     permissions:
       contents: write
       deployments: write
-      issues: write
+      pull-requests: write
 
     steps:
       - name: calculate result

--- a/test/policy.test.js
+++ b/test/policy.test.js
@@ -43,6 +43,7 @@ test("branch deployment keeps trusted logic separate from candidate content", ()
   assert.match(workflow, /"\$\{GITHUB_WORKSPACE\}\/\$\{TRUSTED_PATH\}\/script\/build"/);
   assert.doesNotMatch(workflow, /\$\{WORKING_PATH\}\/script\//);
   assert.doesNotMatch(workflow, /- name: update command reaction/);
+  assert.match(workflow, /result:[\s\S]*?permissions:[\s\S]*?pull-requests: write[\s\S]*?steps:/);
   assert.match(workflow, /- name: complete deployment status\n\s+if: \$\{\{ needs\.trigger\.outputs\.noop != 'true' && needs\.trigger\.outputs\.deployment_id != '' \}\}/);
   assert.match(workflow, /version\.txt\?sha=\$\{EXPECTED_SHA\}/);
 });


### PR DESCRIPTION
## Summary

- grant the result job pull-request write permission required to comment on deployment PRs
- remove the unused issues write permission from that job
- enforce the permission boundary in repository policy tests