### PR TITLE
Audit Fence around Pages artifact uploads

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -67,6 +67,8 @@ jobs:
 
     steps:
       - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
+        with:
+          mode: audit
 
       - name: validate checkout identities
         id: validate

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,6 +45,8 @@ jobs:
 
     steps:
       - uses: openai/fence@db291f5c51949e6e6ec1634621b36dc4bbf3d54a # pin@v0.8.7
+        with:
+          mode: audit
 
       - name: checkout exact source
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # pin@v6.0.3


### PR DESCRIPTION
Fence v0.8.7 intentionally rejects dynamically assigned GitHub results-storage routes used by actions/upload-pages-artifact. This keeps only the two Pages build jobs in audit mode while preserving blocking mode everywhere else and does not add broad Azure Blob hosts or IPs.